### PR TITLE
fix: variables with incorrect names, and track loading format based on lavalink

### DIFF
--- a/src/sources/init.lua
+++ b/src/sources/init.lua
@@ -7,14 +7,14 @@ local class = require('class')
 local Sources = class('Sources')
 
 function Sources:__init()
-  self._avaliable = {}
   if config.luna.soundcloud then
     avaliable["scsearch"] = soundcloud():setup()
   end
 end
 
 function Sources:search(query, source)
-  local getSrc = self._avaliable[source]
+  print("Searching for: " .. query .. " in " .. source)
+  local getSrc = avaliable[source]
   if not getSrc then
     return {
 			loadType = "error",

--- a/src/sources/init.lua
+++ b/src/sources/init.lua
@@ -1,6 +1,6 @@
 local soundcloud = require("../sources/soundcloud.lua")
 local config = require("../utils/config")
-local avaliable = {}
+local avaliables = {}
 
 local class = require('class')
 
@@ -8,7 +8,7 @@ local Sources = class('Sources')
 
 function Sources:__init()
   if config.luna.soundcloud then
-    avaliable["scsearch"] = soundcloud():setup()
+    avaliables["scsearch"] = soundcloud():setup()
   end
 end
 

--- a/src/sources/soundcloud.lua
+++ b/src/sources/soundcloud.lua
@@ -100,7 +100,7 @@ function SoundCloud:search(query)
 
 	return {
 		loadType = "search",
-		tracks = res
+		data = res 
 	}
 end
 
@@ -125,7 +125,7 @@ function SoundCloud:loadForm(query)
 	if body.kind == "track" then
 		return {
 			loadType = "track",
-			tracks = { self:buildTrack(body) },
+			data = self:buildTrack(body),
 		}
 	elseif body.kind == "playlist" then
 		local loaded = {}
@@ -183,7 +183,7 @@ function SoundCloud:loadForm(query)
 				name = body.title,
 				selectedTrack = 0,
 			},
-			tracks = loaded,
+			data = { tracks = loaded },
 		}
 	end
 

--- a/src/track/encoder.lua
+++ b/src/track/encoder.lua
@@ -3,7 +3,7 @@ local required = {
   "author",
   "length",
   "identifier",
-  "isStream",
+  "is_stream",
   "uri"
 }
 
@@ -90,7 +90,7 @@ return function (track)
   writeUTF(track.author)
   writeLong(track.length)
   writeUTF(track.identifier)
-  writeByte(track.isStream and 1 or 0)
+  writeByte(track.is_stream and 1 or 0)
 
   if version >= 2 then
     writeByte(track.uri and 1 or 0)
@@ -109,9 +109,8 @@ return function (track)
       writeUTF(track.isrc)
     end
   end
-
-  writeUTF(track.sourceName)
-  writeLong(track.position)
-
+  
+  writeUTF(track.source_name)
+  writeLong(track.position or 0)
   return toBase64(table.concat(bufferArray))
 end


### PR DESCRIPTION
## desciption

There was a problem when searching for a track in Soundcloud search, because it was calling `self._avaliable` instead of the variable where the evaluated sources were actually being stored, which would just be ´avaliable´ (I'll add an "s" to make it plural)
And something I noticed, that the loading of tracks was indifferent to what the clients and servers use, so I updated it to have more compatibility

## result 
![{74946995-C2A2-411A-9C6B-D912247BFD58}](https://github.com/user-attachments/assets/9d032368-c58a-4f82-bf66-0403c8a842f6)

## usage
Moonlink.js - Bot
Postman :)